### PR TITLE
add Alpha only format for bitmap_create_from_wic_bitmap

### DIFF
--- a/dlls/d2d1/bitmap.c.patch
+++ b/dlls/d2d1/bitmap.c.patch
@@ -1,6 +1,8 @@
+diff --git a/dlls/d2d1/bitmap.c b/dlls/d2d1/bitmap.c
+index c6ab60c1bc4..1df65c768dc 100644
 --- a/dlls/d2d1/bitmap.c
 +++ b/dlls/d2d1/bitmap.c
-@@ -680,11 +680,118 @@ HRESULT d2d_bitmap_create_shared(struct d2d_device_context *context, REFIID iid,
+@@ -680,11 +680,122 @@ HRESULT d2d_bitmap_create_shared(struct d2d_device_context *context, REFIID iid,
          return S_OK;
      }
  
@@ -41,6 +43,7 @@
 +        {&GUID_WICPixelFormat32bppPRGBA, {DXGI_FORMAT_R8G8B8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED}},
 +        {&GUID_WICPixelFormat32bppBGR,   {DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE}},
 +        {&GUID_WICPixelFormat32bppRGB,   {DXGI_FORMAT_R8G8B8A8_UNORM, D2D1_ALPHA_MODE_IGNORE}},
++        {&GUID_WICPixelFormat8bppAlpha,  {DXGI_FORMAT_A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED}},
 +    };
 +
 +    if (FAILED(hr = IWICBitmapLock_GetSize(bitmap_lock, &size.width, &size.height)))
@@ -97,6 +100,9 @@
 +        case DXGI_FORMAT_R8G8B8A8_UNORM:
 +            bpp = 4;
 +            break;
++        case DXGI_FORMAT_A8_UNORM:
++            bpp = 1;
++            break;
 +
 +        default:
 +            FIXME("Unhandled format %#x.\n", bitmap_desc.pixelFormat.format);
@@ -119,7 +125,15 @@
  HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IWICBitmapSource *bitmap_source,
          const D2D1_BITMAP_PROPERTIES1 *desc, struct d2d_bitmap **bitmap)
  {
-@@ -742,6 +849,7 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
+@@ -710,6 +821,7 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
+         {&GUID_WICPixelFormat32bppPRGBA, {DXGI_FORMAT_R8G8B8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED}},
+         {&GUID_WICPixelFormat32bppBGR,   {DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE}},
+         {&GUID_WICPixelFormat32bppRGB,   {DXGI_FORMAT_R8G8B8A8_UNORM, D2D1_ALPHA_MODE_IGNORE}},
++        {&GUID_WICPixelFormat8bppAlpha,  {DXGI_FORMAT_A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED}},
+     };
+ 
+     if (FAILED(hr = IWICBitmapSource_GetSize(bitmap_source, &size.width, &size.height)))
+@@ -742,6 +854,7 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
      {
          if (IsEqualGUID(&wic_format, format_lookup[i].wic))
          {
@@ -127,7 +141,7 @@
              d2d_format = &format_lookup[i].d2d;
              break;
          }
-@@ -750,7 +858,8 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
+@@ -750,7 +863,8 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
      if (!d2d_format)
      {
          WARN("Unsupported WIC bitmap format %s.\n", debugstr_guid(&wic_format));
@@ -137,4 +151,13 @@
      }
  
      if (bitmap_desc.pixelFormat.format == DXGI_FORMAT_UNKNOWN)
-
+@@ -764,6 +878,9 @@ HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IW
+         case DXGI_FORMAT_R8G8B8A8_UNORM:
+             bpp = 4;
+             break;
++        case DXGI_FORMAT_A8_UNORM:
++            bpp = 1;
++            break;
+ 
+         default:
+             FIXME("Unhandled format %#x.\n", bitmap_desc.pixelFormat.format);


### PR DESCRIPTION
Add DXGI_FORMAT_A8_UNORM format needed for selection tool (at least used in 4.3.12)
bpp value same as the one in wic_render_target.c.patch (I assume it means byte per pixel ?)
