### PR TITLE
don't forget \n on TRACE

### DIFF
--- a/dlls/dwrite/font.c.patch
+++ b/dlls/dwrite/font.c.patch
@@ -12,7 +12,7 @@ index f207bade10e..403002d2999 100644
 +static void addSafe(LONG* pos, INT value) {
 +    LONG current = *pos;
 +    LONG result = current + (LONG)value;
-+    TRACE("somehow, this is needed ? optimization issue ?");
++    TRACE("somehow, this is needed ? optimization issue ?\n");
 +    if ((value > 0) && (current > result)) {
 +        *pos = LONG_MAX;
 +    }


### PR DESCRIPTION
I forgot a \n causing a crash sometimes with `err:thread:append_output debug buffer overflow:`
oops

The crash did not seem to happen regularly on my side