### PR TITLE
reimplement Get color context

### DIFF
--- a/dlls/d2d1/command_list.c.patch
+++ b/dlls/d2d1/command_list.c.patch
@@ -1,8 +1,8 @@
 diff --git a/dlls/d2d1/command_list.c b/dlls/d2d1/command_list.c
-index 34242ddd88a..305f1c56abf 100644
+index 6c830d2660e..629ea8ebcd2 100644
 --- a/dlls/d2d1/command_list.c
 +++ b/dlls/d2d1/command_list.c
-@@ -474,8 +474,8 @@ static HRESULT STDMETHODCALLTYPE d2d_command_list_Close(ID2D1CommandList *iface)
+@@ -504,8 +504,8 @@ static HRESULT STDMETHODCALLTYPE d2d_command_list_Close(ID2D1CommandList *iface)
  
      FIXME("iface %p stub.\n", iface);
  
@@ -13,9 +13,9 @@ index 34242ddd88a..305f1c56abf 100644
  
      command_list->state = D2D_COMMAND_LIST_STATE_CLOSED;
  
-@@ -1098,3 +1098,142 @@ void d2d_command_list_fill_opacity_mask(struct d2d_command_list *command_list, c
-     d2d_command_list_write_field(&data, &command->dst_rect, dst_rect, sizeof(*dst_rect));
-     d2d_command_list_write_field(&data, &command->src_rect, src_rect, sizeof(*src_rect));
+@@ -1177,3 +1177,142 @@ void d2d_command_list_fill_opacity_mask(struct d2d_command_list *command_list, c
+         d2d_command_list_write_field(&data, &command->src_rect, src_rect, sizeof(*src_rect));
+     }
  }
 +
 +void d2d_command_list_draw_command(const struct d2d_command *command, struct d2d_device_context *context) {

--- a/dlls/d2d1/d2d1_private.h.patch
+++ b/dlls/d2d1/d2d1_private.h.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/d2d1/d2d1_private.h b/dlls/d2d1/d2d1_private.h
-index 9c78aaf92e2..ef5007bc111 100644
+index ba6cea78e06..b949651fbac 100644
 --- a/dlls/d2d1/d2d1_private.h
 +++ b/dlls/d2d1/d2d1_private.h
 @@ -455,6 +455,8 @@ HRESULT d2d_bitmap_create(struct d2d_device_context *context, D2D1_SIZE_U size,
@@ -11,7 +11,7 @@ index 9c78aaf92e2..ef5007bc111 100644
  HRESULT d2d_bitmap_create_from_wic_bitmap(struct d2d_device_context *context, IWICBitmapSource *bitmap_source,
          const D2D1_BITMAP_PROPERTIES1 *desc, struct d2d_bitmap **bitmap);
  unsigned int d2d_get_bitmap_options_for_surface(IDXGISurface *surface);
-@@ -939,6 +941,7 @@ void d2d_command_list_fill_opacity_mask(struct d2d_command_list *command_list, c
+@@ -964,6 +966,7 @@ void d2d_command_list_fill_opacity_mask(struct d2d_command_list *command_list, c
  void d2d_command_list_push_layer(struct d2d_command_list *command_list, const struct d2d_device_context *context,
          const D2D1_LAYER_PARAMETERS1 *params);
  void d2d_command_list_pop_layer(struct d2d_command_list *command_list);
@@ -19,7 +19,7 @@ index 9c78aaf92e2..ef5007bc111 100644
  
  static inline BOOL d2d_array_reserve(void **elements, size_t *capacity, size_t count, size_t size)
  {
-@@ -1094,4 +1097,20 @@ static inline const char *debug_d2d_ellipse(const D2D1_ELLIPSE *ellipse)
+@@ -1119,4 +1122,20 @@ static inline const char *debug_d2d_ellipse(const D2D1_ELLIPSE *ellipse)
              ellipse->point.x, ellipse->point.y, ellipse->radiusX, ellipse->radiusY);
  }
  

--- a/dlls/dwrite/font.c.patch
+++ b/dlls/dwrite/font.c.patch
@@ -1,8 +1,8 @@
 diff --git a/dlls/dwrite/font.c b/dlls/dwrite/font.c
-index f207bade10e..8bb937a07a0 100644
+index 9544784b8cc..71fcf8b231c 100644
 --- a/dlls/dwrite/font.c
 +++ b/dlls/dwrite/font.c
-@@ -5831,6 +5831,29 @@ static ULONG WINAPI glyphrunanalysis_Release(IDWriteGlyphRunAnalysis *iface)
+@@ -5828,6 +5828,29 @@ static ULONG WINAPI glyphrunanalysis_Release(IDWriteGlyphRunAnalysis *iface)
      return refcount;
  }
  
@@ -32,7 +32,7 @@ index f207bade10e..8bb937a07a0 100644
  static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *analysis, RECT *bounds)
  {
      struct dwrite_glyphbitmap glyph_bitmap;
-@@ -5862,7 +5885,7 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
+@@ -5859,7 +5882,7 @@ static void glyphrunanalysis_get_texturebounds(struct dwrite_glyphrunanalysis *a
          if (bitmap_size > analysis->max_glyph_bitmap_size)
              analysis->max_glyph_bitmap_size = bitmap_size;
  

--- a/dlls/windowscodecs/info.c.patch
+++ b/dlls/windowscodecs/info.c.patch
@@ -1,8 +1,8 @@
 diff --git a/dlls/windowscodecs/info.c b/dlls/windowscodecs/info.c
-index 4063196e27c..b869f15c6d7 100644
+index 4063196e27c..3722a8f7eff 100644
 --- a/dlls/windowscodecs/info.c
 +++ b/dlls/windowscodecs/info.c
-@@ -1331,11 +1331,107 @@ static HRESULT WINAPI PixelFormatInfo_GetFormatGUID(IWICPixelFormatInfo2 *iface,
+@@ -1331,10 +1331,132 @@ static HRESULT WINAPI PixelFormatInfo_GetFormatGUID(IWICPixelFormatInfo2 *iface,
      return S_OK;
  }
  
@@ -90,24 +90,49 @@ index 4063196e27c..b869f15c6d7 100644
  static HRESULT WINAPI PixelFormatInfo_GetColorContext(IWICPixelFormatInfo2 *iface,
      IWICColorContext **ppIColorContext)
  {
+-    FIXME("(%p,%p): stub\n", iface, ppIColorContext);
 +    HRESULT hr;
 +    IWICPixelFormatInfo *iface1;
-+    UINT bpp;
-+    UINT channel;
++    GUID formatuuid;
++    WICPixelFormatNumericRepresentation repr;
 +
-     FIXME("(%p,%p): stub\n", iface, ppIColorContext);
--    return E_NOTIMPL;
++    TRACE("(%p,%p)\n", iface, ppIColorContext);
 +
-+    if(FAILED(hr = IWICPixelFormatInfo2_QueryInterface(iface, &IID_IWICPixelFormatInfo, (void **)&iface1)))
++    if (FAILED(hr = IWICPixelFormatInfo2_GetNumericRepresentation(iface, &repr)))
++        return hr;
++    if (FAILED(hr = IWICPixelFormatInfo2_QueryInterface(iface, &IID_IWICPixelFormatInfo, (void **)&iface1)))
++        return hr;
++    if (FAILED(hr = IWICPixelFormatInfo_GetFormatGUID(iface1, &formatuuid)))
 +        return hr;
 +
-+    IWICPixelFormatInfo_GetBitsPerPixel(iface1, &bpp);
-+    IWICPixelFormatInfo_GetChannelCount(iface1, &channel);
++    // "Alpha8 returns null" aparently
++    if ((IsEqualGUID(&GUID_WICPixelFormat8bppAlpha, &formatuuid)))
++    {
++        *ppIColorContext = NULL;
++        return S_OK;
++    }
 +
 +    ColorContext_Create(ppIColorContext);
-+    if(bpp/channel < 16)
++    // we need to determine if in one of the special case
++    if (IsEqualGUID(&GUID_WICPixelFormat32bppCMYK, &formatuuid) ||
++        IsEqualGUID(&GUID_WICPixelFormat64bppCMYK, &formatuuid) ||
++        IsEqualGUID(&GUID_WICPixelFormat40bppCMYKAlpha, &formatuuid) ||
++        IsEqualGUID(&GUID_WICPixelFormat80bppCMYKAlpha, &formatuuid))
++    {
++        FIXME("CMYK profile is not yet implemented\n");
++        return E_NOTIMPL;
++    }
++
++    if (repr == WICPixelFormatNumericRepresentationIndexed ||
++        repr == WICPixelFormatNumericRepresentationUnsignedInteger ||
++        repr == WICPixelFormatNumericRepresentationSignedInteger)
 +        return IWICColorContext_InitializeFromMemory(*ppIColorContext, SRGB_ICC_COLOR_PROFILE, sizeof(SRGB_ICC_COLOR_PROFILE));
-+    return IWICColorContext_InitializeFromMemory(*ppIColorContext, SCRGB_ICC_COLOR_PROFILE, sizeof(SCRGB_ICC_COLOR_PROFILE));
++    else if (repr == WICPixelFormatNumericRepresentationFixed ||
++        WICPixelFormatNumericRepresentationFloat)
++        return IWICColorContext_InitializeFromMemory(*ppIColorContext, SCRGB_ICC_COLOR_PROFILE, sizeof(SCRGB_ICC_COLOR_PROFILE));
++
++    FIXME("Unkown color context for file format %u\n", repr);
++    *ppIColorContext = NULL;
+     return E_NOTIMPL;
  }
  
- static HRESULT WINAPI PixelFormatInfo_GetBitsPerPixel(IWICPixelFormatInfo2 *iface,


### PR DESCRIPTION
after the first implementation, Rick made me aware of GetNumericRepresentation for better implementation with edge case for cymk & alpha 8bpp